### PR TITLE
Pass arguments to skype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,6 @@ EXPOSE 22
 
 # Start SSH
 ENTRYPOINT ["/usr/sbin/sshd",  "-D"]
+
+# Do not pass default command to sshd
+CMD []


### PR DESCRIPTION
Pass arguments from `skype-pulseaudio` wrapper to skype binary. Useful for `--secondary` flag.
