### PR TITLE
Add lib4l-0:i386 as dependency and preload skype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update
 
 
 # Install PulseAudio for i386 (64bit version does not work with Skype)
-RUN apt-get install -y libpulse0:i386 pulseaudio:i386
+RUN apt-get install -y libpulse0:i386 pulseaudio:i386 libv4l-0:i386
 
 # We need ssh to access the docker container, wget to download skype
 RUN apt-get install -y openssh-server wget 
@@ -42,7 +42,7 @@ RUN echo "Europe/Prague" > /etc/timezone
 
 # Set up the launch wrapper - sets up PulseAudio to work correctly
 RUN echo 'export PULSE_SERVER="tcp:localhost:64713"' >> /usr/local/bin/skype-pulseaudio
-RUN echo 'PULSE_LATENCY_MSEC=60 skype' >> /usr/local/bin/skype-pulseaudio
+RUN echo 'env PULSE_LATENCY_MSEC=60e LD_PRELOAD=/usr/lib/i386-linux-gnu/libv4l/v4l2convert.so skype' >> /usr/local/bin/skype-pulseaudio
 RUN chmod 755 /usr/local/bin/skype-pulseaudio
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN echo "Europe/Prague" > /etc/timezone
 
 # Set up the launch wrapper - sets up PulseAudio to work correctly
 RUN echo 'export PULSE_SERVER="tcp:localhost:64713"' >> /usr/local/bin/skype-pulseaudio
-RUN echo 'env PULSE_LATENCY_MSEC=60e LD_PRELOAD=/usr/lib/i386-linux-gnu/libv4l/v4l2convert.so skype' >> /usr/local/bin/skype-pulseaudio
+RUN echo 'env PULSE_LATENCY_MSEC=60 LD_PRELOAD=/usr/lib/i386-linux-gnu/libv4l/v4l2convert.so skype' >> /usr/local/bin/skype-pulseaudio
 RUN chmod 755 /usr/local/bin/skype-pulseaudio
 
 


### PR DESCRIPTION
On some laptops, the camera is mounted upside/down. So we must add libv4l-0:i386 as dependency an preload skype through it to have skype display the image correctly. 