### PR TITLE
 Allowing container to use webcam device

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update
 RUN apt-get install -y libpulse0:i386 pulseaudio:i386
 
 # We need ssh to access the docker container, wget to download skype
-RUN apt-get install -y openssh-server wget 
+RUN apt-get install -y openssh-server wget
 
 # Install Skype
 RUN wget http://download.skype.com/linux/skype-debian_4.3.0.37-1_i386.deb -O /usr/src/skype.deb
@@ -23,8 +23,11 @@ RUN dpkg -i /usr/src/skype.deb || true
 RUN apt-get install -fy						# Automatically detect and install dependencies
 
 
-# Create user "docker" and set the password to "docker"
-RUN useradd -m -d /home/docker docker
+# Create user "docker", set the password to "docker",
+# change the proprietary of $HOME and append the new user to audio and video groups
+RUN useradd -m -d /home/docker docker \
+    && chown -R docker:docker $HOME \
+    && usermod -a -G audio,video docker
 RUN echo "docker:docker" | chpasswd
 
 # Create OpenSSH privilege separation directory, enable X11Forwarding

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ In case you do not want to download the prepared image, you can built the image 
 3. Restart PulseAudio
 
         sudo service pulseaudio restart
-   
+
     or
-   
+
         pulseaudio -k
         pulseaudio --start
 
     On some distributions, it may be necessary to completely restart your computer. You can confirm that the settings have successfully been applied using the `pax11publish` command. You should see something like this (the important part is in bold):
 
     > Server: {ShortAlphanumericString}unix:/run/user/1000/pulse/native **tcp:YourHostname:4713 tcp6:YourHostname:4713**
-    
+
     > Cookie: ReallyLongAlphanumericString
 
 4. [Install Docker](http://docs.docker.io/en/latest/installation/) if you haven't already
@@ -47,22 +47,26 @@ In case you do not want to download the prepared image, you can built the image 
         sudo docker build -t skype .
 
 7. Create an entry in your .ssh/config file for easy access. It should look like this:
-        
+
         Host docker-skype
           User      docker
           Port      55555
           HostName  127.0.0.1
           RemoteForward 64713 localhost:4713
           ForwardX11 yes
-          
+
     (Optional) I recommend creating an SSH key without a password to be used to connect to this container.
     So in case you used a non-standard filename for your SSH key, add this:
-   
+
           IdentityFile /path/to/your/ssh/key
 
 8. Run the container and forward the appropriate port
 
         sudo docker run -d -p 55555:22 skype
+
+    (Optional) Run the container with access to your webcam:
+
+        sudo docker run -d -p 55555:22 -v /tmp/.X11-unix:/tmp/.X11-unix --device /dev/video0 skype
 
 9. (Optional) Copy an SSH public key
 
@@ -73,7 +77,7 @@ In case you do not want to download the prepared image, you can built the image 
 10. Connect via SSH and launch Skype using the provided PulseAudio wrapper script
 
         ssh docker-skype skype-pulseaudio
-     
+
     In case you didn't copy the SSH public key, the password is `docker`.
 
 11. Go use Skype in a safe container!


### PR DESCRIPTION
I built the Dockerfile and couldn't use my webcam on skype, so I added a couple lines to the Dockerfile. Now I can use the webcam by running the image as follow:

```
sudo docker run -d -p 55555:22 -v /tmp/.X11-unix:/tmp/.X11-unix --device /dev/video0 skype
```
